### PR TITLE
Add explicit nullable param types (PHP 8.4 deprecation)

### DIFF
--- a/src/Model/Tables/MelisCmsNewsTagsTable.php
+++ b/src/Model/Tables/MelisCmsNewsTagsTable.php
@@ -66,7 +66,7 @@ class MelisCmsNewsTagsTable extends MelisGenericTable
         $key1Value,
         array $newKey2Values,
         $where = null,
-        array $otherValues = null
+        ?array $otherValues = null
     ) {
         $sql = new Sql($adapter);
 

--- a/src/Model/Tables/MelisCmsNewsTextsTable.php
+++ b/src/Model/Tables/MelisCmsNewsTextsTable.php
@@ -67,7 +67,7 @@ class MelisCmsNewsTextsTable extends MelisGenericTable
      * @param int|null $postId
      * @return null
      */
-    public function getPostTitle(int $postId = null)
+    public function getPostTitle(?int $postId = null)
     {
         if (empty($postId)) {
             return null;

--- a/src/Service/MelisCmsNewsService.php
+++ b/src/Service/MelisCmsNewsService.php
@@ -259,7 +259,7 @@ class MelisCmsNewsService extends MelisGeneralService
      * @param int|null $newsId
      * @return mixed
      */
-    public function getPostText(int $newsId = null)
+    public function getPostText(?int $newsId = null)
     {
         // Event parameters prepare
         $arrayParameters = $this->makeArrayFromParameters(__METHOD__, func_get_args());
@@ -292,7 +292,7 @@ class MelisCmsNewsService extends MelisGeneralService
      * @param int|null $siteId
      * @return mixed
      */
-    public function getNewsDetailsPagesBySite(int $siteId = null)
+    public function getNewsDetailsPagesBySite(?int $siteId = null)
     {
         // Event parameters prepare
         $arrayParameters = $this->makeArrayFromParameters(__METHOD__, func_get_args());


### PR DESCRIPTION
## What

PHP 8.4 deprecates **implicitly nullable parameters** (`Type $x = null`). This makes them explicit (`?Type $x = null`) in `src/`.

## Safety

**Behaviour-preserving** (PHP already treats `Type $x = null` as nullable). Generated with PHP-CS-Fixer (`nullable_type_declaration_for_default_null_value`), `php -l` clean — `?`-only changes, no logic change.

## Context

Part of the PHP 8.4 support effort (melisplatform/melis-core#24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)